### PR TITLE
Feat: 엔티티 및 리포지토리 셋팅

### DIFF
--- a/src/main/java/swyp/team5/greening/comment/domain/entity/Comment.java
+++ b/src/main/java/swyp/team5/greening/comment/domain/entity/Comment.java
@@ -1,0 +1,29 @@
+package swyp.team5.greening.comment.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "comments")
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "comment_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "comment")
+    private String comment;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "post_id")
+    private Long postId;
+
+}

--- a/src/main/java/swyp/team5/greening/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/swyp/team5/greening/comment/domain/repository/CommentRepository.java
@@ -1,0 +1,5 @@
+package swyp.team5.greening.comment.domain.repository;
+
+public interface CommentRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/comment/infrastructure/CommentJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/comment/infrastructure/CommentJpaRepository.java
@@ -1,0 +1,9 @@
+package swyp.team5.greening.comment.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.team5.greening.comment.domain.entity.Comment;
+import swyp.team5.greening.comment.domain.repository.CommentRepository;
+
+public interface CommentJpaRepository extends JpaRepository<Long, Comment>, CommentRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/common/base/AuditingConfig.java
+++ b/src/main/java/swyp/team5/greening/common/base/AuditingConfig.java
@@ -1,0 +1,10 @@
+package swyp.team5.greening.common.base;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class AuditingConfig {
+
+}

--- a/src/main/java/swyp/team5/greening/common/base/BaseTimeEntity.java
+++ b/src/main/java/swyp/team5/greening/common/base/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package swyp.team5.greening.common.base;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/swyp/team5/greening/mbti/domain/entity/Mbti.java
+++ b/src/main/java/swyp/team5/greening/mbti/domain/entity/Mbti.java
@@ -1,0 +1,31 @@
+package swyp.team5.greening.mbti.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "mbti")
+public class Mbti extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "mbti_id")
+    @GeneratedValue
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mbti_type")
+    private MbtiType mbtiType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plant_id")
+    private MbtiPlant plant;
+}

--- a/src/main/java/swyp/team5/greening/mbti/domain/entity/MbtiPlant.java
+++ b/src/main/java/swyp/team5/greening/mbti/domain/entity/MbtiPlant.java
@@ -1,0 +1,44 @@
+package swyp.team5.greening.mbti.domain.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "mbti_plants")
+public class MbtiPlant extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "plant_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "plant_name")
+    private String plantName;
+
+    @Column(name = "plant_description")
+    private String plantDescription;
+
+    @Column(name = "plant_personality")
+    private String plantPersonality;
+
+    @Column(name = "suitable_plant")
+    private String suitablePlant;
+
+    @Column(name = "unsuitable_plant")
+    private String unsuitablePlant;
+
+    @Column(name = "recommended_plant")
+    private String recommendedPlant;
+
+    @OneToMany(mappedBy = "mbtiPlant", cascade = {CascadeType.PERSIST}, orphanRemoval = true)
+    private final List<PlantImage> plantImages = new ArrayList<>();
+}

--- a/src/main/java/swyp/team5/greening/mbti/domain/entity/MbtiType.java
+++ b/src/main/java/swyp/team5/greening/mbti/domain/entity/MbtiType.java
@@ -1,0 +1,4 @@
+package swyp.team5.greening.mbti.domain.entity;
+
+public enum MbtiType {
+}

--- a/src/main/java/swyp/team5/greening/mbti/domain/entity/PlantImage.java
+++ b/src/main/java/swyp/team5/greening/mbti/domain/entity/PlantImage.java
@@ -1,0 +1,27 @@
+package swyp.team5.greening.mbti.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "plant_images")
+public class PlantImage extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "plant_image_id")
+    private Long id;
+
+    @Column(name = "plant_image_url")
+    private String plantImageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plant_id")
+    private MbtiPlant mbtiPlant;
+
+}

--- a/src/main/java/swyp/team5/greening/mbti/domain/repository/MbtiRepository.java
+++ b/src/main/java/swyp/team5/greening/mbti/domain/repository/MbtiRepository.java
@@ -1,0 +1,5 @@
+package swyp.team5.greening.mbti.domain.repository;
+
+public interface MbtiRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/mbti/infrastructure/MbtiJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/mbti/infrastructure/MbtiJpaRepository.java
@@ -1,0 +1,9 @@
+package swyp.team5.greening.mbti.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.team5.greening.mbti.domain.entity.Mbti;
+import swyp.team5.greening.mbti.domain.repository.MbtiRepository;
+
+public interface MbtiJpaRepository extends JpaRepository<Long , Mbti>, MbtiRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/mbtiQnA/domain/entity/MbtiAnswer.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/domain/entity/MbtiAnswer.java
@@ -1,0 +1,43 @@
+package swyp.team5.greening.mbtiQnA.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "mbti_answers")
+public class MbtiAnswer extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "mbti_answer_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "answer")
+    private String answer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mbti_answer_type")
+    private MbtiAnswerType answerType;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mbti_each")
+    private MbtiEach mbtiEach;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mbti_question_id")
+    private MbtiQuestion mbtiQuestion;
+
+}

--- a/src/main/java/swyp/team5/greening/mbtiQnA/domain/entity/MbtiAnswerType.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/domain/entity/MbtiAnswerType.java
@@ -1,0 +1,6 @@
+package swyp.team5.greening.mbtiQnA.domain.entity;
+
+public enum MbtiAnswerType {
+    A,
+    B
+}

--- a/src/main/java/swyp/team5/greening/mbtiQnA/domain/entity/MbtiEach.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/domain/entity/MbtiEach.java
@@ -1,0 +1,7 @@
+package swyp.team5.greening.mbtiQnA.domain.entity;
+
+public enum MbtiEach {
+    E, I,
+    N, S,
+    F, T
+}

--- a/src/main/java/swyp/team5/greening/mbtiQnA/domain/entity/MbtiQuestion.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/domain/entity/MbtiQuestion.java
@@ -1,0 +1,23 @@
+package swyp.team5.greening.mbtiQnA.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "mbti_questions")
+public class MbtiQuestion extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "mbti_question_id")
+    private Long id;
+
+    @Column(name = "question_text")
+    private String questionText;
+
+    @Column(name = "sequence")
+    private Integer sequence;
+
+}

--- a/src/main/java/swyp/team5/greening/mbtiQnA/domain/repository/MbtiAnswerRepository.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/domain/repository/MbtiAnswerRepository.java
@@ -1,0 +1,5 @@
+package swyp.team5.greening.mbtiQnA.domain.repository;
+
+public interface MbtiAnswerRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/mbtiQnA/domain/repository/MbtiQuestionRepository.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/domain/repository/MbtiQuestionRepository.java
@@ -1,0 +1,5 @@
+package swyp.team5.greening.mbtiQnA.domain.repository;
+
+public interface MbtiQuestionRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/mbtiQnA/infrastructure/MbtiJpaAnswerRepository.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/infrastructure/MbtiJpaAnswerRepository.java
@@ -1,0 +1,10 @@
+package swyp.team5.greening.mbtiQnA.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.team5.greening.mbtiQnA.domain.entity.MbtiAnswer;
+import swyp.team5.greening.mbtiQnA.domain.repository.MbtiAnswerRepository;
+
+public interface MbtiJpaAnswerRepository extends JpaRepository<Long, MbtiAnswer>,
+        MbtiAnswerRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/mbtiQnA/infrastructure/MbtiQuestionJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/infrastructure/MbtiQuestionJpaRepository.java
@@ -1,0 +1,10 @@
+package swyp.team5.greening.mbtiQnA.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.team5.greening.mbtiQnA.domain.entity.MbtiQuestion;
+import swyp.team5.greening.mbtiQnA.domain.repository.MbtiQuestionRepository;
+
+public interface MbtiQuestionJpaRepository extends JpaRepository<Long, MbtiQuestion>,
+        MbtiQuestionRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/post/domain/entity/Post.java
+++ b/src/main/java/swyp/team5/greening/post/domain/entity/Post.java
@@ -1,0 +1,51 @@
+package swyp.team5.greening.post.domain.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "posts")
+public class Post extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "post_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "like_count")
+    private Long likeCount;
+
+    @Column(name = "comment_count")
+    private Long commentCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "state")
+    private PostState state;
+
+    @Column(name = "category_id")
+    private Long categoryId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @OneToMany(mappedBy = "post", cascade = {CascadeType.PERSIST}, orphanRemoval = true)
+    private final List<PostImage> postImages = new ArrayList<>();
+
+}

--- a/src/main/java/swyp/team5/greening/post/domain/entity/PostImage.java
+++ b/src/main/java/swyp/team5/greening/post/domain/entity/PostImage.java
@@ -1,0 +1,30 @@
+package swyp.team5.greening.post.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "post_images")
+public class PostImage extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "post_image_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "post_image_url")
+    private String postImageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+}

--- a/src/main/java/swyp/team5/greening/post/domain/entity/PostState.java
+++ b/src/main/java/swyp/team5/greening/post/domain/entity/PostState.java
@@ -1,0 +1,8 @@
+package swyp.team5.greening.post.domain.entity;
+
+public enum PostState {
+
+    IN_PROGRESS,
+    DELETED
+
+}

--- a/src/main/java/swyp/team5/greening/post/domain/repository/PostRepository.java
+++ b/src/main/java/swyp/team5/greening/post/domain/repository/PostRepository.java
@@ -1,0 +1,5 @@
+package swyp.team5.greening.post.domain.repository;
+
+public interface PostRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/post/infrastructure/PostJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/post/infrastructure/PostJpaRepository.java
@@ -1,0 +1,8 @@
+package swyp.team5.greening.post.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.team5.greening.post.domain.entity.Post;
+import swyp.team5.greening.post.domain.repository.PostRepository;
+
+public interface PostJpaRepository extends JpaRepository<Post, Long>, PostRepository {
+}

--- a/src/main/java/swyp/team5/greening/postCategory/domain/entity/Category.java
+++ b/src/main/java/swyp/team5/greening/postCategory/domain/entity/Category.java
@@ -1,0 +1,26 @@
+package swyp.team5.greening.postCategory.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "category")
+public class Category extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "category_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category_type")
+    private CategoryType categoryType;
+
+}

--- a/src/main/java/swyp/team5/greening/postCategory/domain/entity/CategoryType.java
+++ b/src/main/java/swyp/team5/greening/postCategory/domain/entity/CategoryType.java
@@ -1,0 +1,4 @@
+package swyp.team5.greening.postCategory.domain.entity;
+
+public enum CategoryType {
+}

--- a/src/main/java/swyp/team5/greening/postCategory/domain/repository/CategoryRepository.java
+++ b/src/main/java/swyp/team5/greening/postCategory/domain/repository/CategoryRepository.java
@@ -1,0 +1,5 @@
+package swyp.team5.greening.postCategory.domain.repository;
+
+public interface CategoryRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/postCategory/infrastructure/CategoryJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/postCategory/infrastructure/CategoryJpaRepository.java
@@ -1,0 +1,9 @@
+package swyp.team5.greening.postCategory.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.team5.greening.postCategory.domain.entity.Category;
+import swyp.team5.greening.postCategory.domain.repository.CategoryRepository;
+
+public interface CategoryJpaRepository extends JpaRepository<Long, Category>, CategoryRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/postLike/domain/entity/Like.java
+++ b/src/main/java/swyp/team5/greening/postLike/domain/entity/Like.java
@@ -1,0 +1,26 @@
+package swyp.team5.greening.postLike.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "likes")
+public class Like extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "like_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "post_id")
+    private Long postId;
+
+}

--- a/src/main/java/swyp/team5/greening/postLike/domain/repository/LikeRepository.java
+++ b/src/main/java/swyp/team5/greening/postLike/domain/repository/LikeRepository.java
@@ -1,0 +1,5 @@
+package swyp.team5.greening.postLike.domain.repository;
+
+public interface LikeRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/postLike/infrastructure/LikeJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/postLike/infrastructure/LikeJpaRepository.java
@@ -1,0 +1,9 @@
+package swyp.team5.greening.postLike.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.team5.greening.postLike.domain.entity.Like;
+import swyp.team5.greening.postLike.domain.repository.LikeRepository;
+
+public interface LikeJpaRepository extends JpaRepository<Long, Like>, LikeRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/user/domain/entity/LoginType.java
+++ b/src/main/java/swyp/team5/greening/user/domain/entity/LoginType.java
@@ -1,0 +1,7 @@
+package swyp.team5.greening.user.domain.entity;
+
+public enum LoginType {
+    KAKAO,
+    GOOGLE
+
+}

--- a/src/main/java/swyp/team5/greening/user/domain/entity/User.java
+++ b/src/main/java/swyp/team5/greening/user/domain/entity/User.java
@@ -1,0 +1,35 @@
+package swyp.team5.greening.user.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import swyp.team5.greening.common.base.BaseTimeEntity;
+
+@Entity
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email")
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_type")
+    private LoginType loginType;
+
+    @Column(name = "user_name")
+    private String userName;
+
+    @Column(name = "nickname")
+    private String nickname;
+
+}

--- a/src/main/java/swyp/team5/greening/user/domain/repository/UserRepository.java
+++ b/src/main/java/swyp/team5/greening/user/domain/repository/UserRepository.java
@@ -1,0 +1,5 @@
+package swyp.team5.greening.user.domain.repository;
+
+public interface UserRepository {
+
+}

--- a/src/main/java/swyp/team5/greening/user/infrastructure/UserJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/user/infrastructure/UserJpaRepository.java
@@ -1,0 +1,9 @@
+package swyp.team5.greening.user.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import swyp.team5.greening.user.domain.entity.User;
+import swyp.team5.greening.user.domain.repository.UserRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long>, UserRepository {
+
+}


### PR DESCRIPTION
- closed #3

### ⛏ 작업 상세 내용
- 각 도메인 별 엔티티 및 리포지토리 셋팅

### ✅ 중점적으로 리뷰 할 부분
- 지정 테이블과 다르게 정의한 부분이 없는지

### 참고사항
- JpaRepository를 인터페이스를 통해 접근하도록 하였습니다.