### PR TITLE
Feat: 공통 예외 클래스 및 예외 처리 핸들러 구현

### DIFF
--- a/src/main/java/swyp/team5/greening/common/exception/ExceptionMessage.java
+++ b/src/main/java/swyp/team5/greening/common/exception/ExceptionMessage.java
@@ -1,0 +1,9 @@
+package swyp.team5.greening.common.exception;
+
+public interface ExceptionMessage {
+
+    String getMessage();
+
+    String getCode();
+
+}

--- a/src/main/java/swyp/team5/greening/common/exception/ExceptionResponse.java
+++ b/src/main/java/swyp/team5/greening/common/exception/ExceptionResponse.java
@@ -1,0 +1,7 @@
+package swyp.team5.greening.common.exception;
+
+public record ExceptionResponse(
+        String message
+) {
+
+}

--- a/src/main/java/swyp/team5/greening/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/swyp/team5/greening/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package swyp.team5.greening.common.exception;
+
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private final String ARGUMENT_NOT_VALID_MESSAGE = "잘못된 입력 값입니다.";
+
+    // Validation 예외를 처리하는 핸들러
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException exception
+    ) {
+        String message = Objects.requireNonNullElse(
+                exception.getBindingResult()
+                        .getAllErrors()
+                        .get(0).getDefaultMessage(),
+                ARGUMENT_NOT_VALID_MESSAGE);
+
+        log.error("HttpStatus : {}, Exception Message : {}",
+                exception.getStatusCode(),
+                message);
+
+        return new ResponseEntity<>(new ExceptionResponse(message), exception.getStatusCode());
+    }
+
+    //커스텀 예외 처리 핸들러
+    @ExceptionHandler(GreeningGlobalException.class)
+    public ResponseEntity<ExceptionResponse> globalExceptionHandler(
+            GreeningGlobalException exception
+    ) {
+        String message = exception.getMessage();
+        String code = exception.getCode();
+
+        log.error("HttpStatus : {}, Exception Message : {}", code, message);
+
+        return new ResponseEntity<>(new ExceptionResponse(message),
+                HttpStatusCode.valueOf(Integer.parseInt(code)));
+    }
+}

--- a/src/main/java/swyp/team5/greening/common/exception/GreeningGlobalException.java
+++ b/src/main/java/swyp/team5/greening/common/exception/GreeningGlobalException.java
@@ -1,0 +1,15 @@
+package swyp.team5.greening.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GreeningGlobalException extends RuntimeException{
+
+    private String code;
+
+    public GreeningGlobalException(ExceptionMessage message) {
+        super(message.getMessage());
+        this.code = message.getCode();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/greening
+    username: root
+    password: 1234
+
+  sql:
+    init:
+      mode: never
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    defer-datasource-initialization: true
+    open-in-view: false
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true


### PR DESCRIPTION
- closed #5 

### ⛏ 작업 상세 내용

- 예외 처리에 필요한 공통 클래스 및 처리 핸들러 구현

### ✅ 중점적으로 리뷰 할 부분

### 참고사항

#### 예외 처리 시, 
1. ExceptionMessage를 상속받는 Enum 클래스 생성한다 -> PostExceptionMessage
2.  PostExceptionMessage의 예외 메시지 및 Http 응답 코드를 작성한다.
```
TEST_EXCEPTION_MESSAGE("테스트 예외입니다", "404")
```
3. 예외를 던지는 곳에 다음과 같이 작성한다.
```
thorw new GreegningGlobalException(PostExceptionMessage.TEST_EXCEPTION_MESSAGE);
```
