### PR TITLE
Feat: 카카오 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.4'
+    id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/src/main/java/swyp/team5/greening/auth/config/FilterConfig.java
+++ b/src/main/java/swyp/team5/greening/auth/config/FilterConfig.java
@@ -7,17 +7,22 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import swyp.team5.greening.auth.filter.AuthenticationFilter;
 import swyp.team5.greening.auth.filter.JwtExceptionHandlerFilter;
+import swyp.team5.greening.auth.infrastructure.JwtTokenProvider;
 
 @Configuration
 @RequiredArgsConstructor
 public class FilterConfig {
 
-    private final JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
-    private final AuthenticationFilter authenticationFilter;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private JwtExceptionHandlerFilter jwtExceptionHandlerFilter;
+    private AuthenticationFilter authenticationFilter;
 
     //필터 체인 -> 예외 관련 예외 필터 추가
     @Bean
     public FilterRegistrationBean<Filter> exceptionHandlerFilter() {
+        jwtExceptionHandlerFilter = new JwtExceptionHandlerFilter();
+
         FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
 
         registrationBean.setFilter(jwtExceptionHandlerFilter);
@@ -31,6 +36,8 @@ public class FilterConfig {
     //필터 체인 -> 인증 필터 추가
     @Bean
     public FilterRegistrationBean<Filter> authenticationFilter() {
+        authenticationFilter = new AuthenticationFilter(jwtTokenProvider);
+
         FilterRegistrationBean<Filter> registrationBean = new FilterRegistrationBean<>();
 
         registrationBean.setFilter(authenticationFilter);

--- a/src/main/java/swyp/team5/greening/auth/exception/AuthExceptionMessage.java
+++ b/src/main/java/swyp/team5/greening/auth/exception/AuthExceptionMessage.java
@@ -12,7 +12,8 @@ public enum AuthExceptionMessage implements ExceptionMessage {
     AUTH_TOKEN_EXPIRED("기한이 만료된 토큰입니다", "401"),
     AUTH_TOKEN_UNSUPPORTED("지원하지 않는 토큰입니다", "401"),
     AUTH_TOKEN_ILLEGAL("claims 정보가 비어있습니다", "401"),
-    AUTH_TOKEN_NOT_SIGNATURE("Jwt 서명이 로컬로 산정된 서명과 일치하지 않습니다", "401");
+    AUTH_TOKEN_NOT_SIGNATURE("Jwt 서명이 로컬로 산정된 서명과 일치하지 않습니다", "401"),
+    UNAUTHORIZED("로그인이 필요한 서비스입니다.", "401");
 
     private final String message;
     private final String code;

--- a/src/main/java/swyp/team5/greening/auth/filter/AuthenticationFilter.java
+++ b/src/main/java/swyp/team5/greening/auth/filter/AuthenticationFilter.java
@@ -7,12 +7,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import swyp.team5.greening.auth.provider.TokenProvider;
 
-@Component
 @RequiredArgsConstructor
 public class AuthenticationFilter extends OncePerRequestFilter {
 

--- a/src/main/java/swyp/team5/greening/auth/filter/JwtExceptionHandlerFilter.java
+++ b/src/main/java/swyp/team5/greening/auth/filter/JwtExceptionHandlerFilter.java
@@ -14,7 +14,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import swyp.team5.greening.auth.exception.AuthException;
 import swyp.team5.greening.common.exception.ExceptionResponse;
 
-@Component
 @Slf4j
 public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
 

--- a/src/main/java/swyp/team5/greening/comment/infrastructure/CommentJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/comment/infrastructure/CommentJpaRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.team5.greening.comment.domain.entity.Comment;
 import swyp.team5.greening.comment.domain.repository.CommentRepository;
 
-public interface CommentJpaRepository extends JpaRepository<Long, Comment>, CommentRepository {
+public interface CommentJpaRepository extends JpaRepository<Comment, Long>, CommentRepository {
 
 }

--- a/src/main/java/swyp/team5/greening/common/config/SwaggerConfig.java
+++ b/src/main/java/swyp/team5/greening/common/config/SwaggerConfig.java
@@ -26,6 +26,7 @@ public class SwaggerConfig {
 
         SecurityRequirement securityRequirement = new SecurityRequirement()
                 .addList(accessToken);
+
         Components components = new Components()
                 .addSecuritySchemes(accessToken,
                         new SecurityScheme()

--- a/src/main/java/swyp/team5/greening/common/config/SwaggerConfig.java
+++ b/src/main/java/swyp/team5/greening/common/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package swyp.team5.greening.common.config;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+//http://localhost:8000/api-docs
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Greening API",
+                description = "Greening API 명세",
+                version = "v1"))
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String accessToken = "ACCESS_TOKEN";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList(accessToken);
+        Components components = new Components()
+                .addSecuritySchemes(accessToken,
+                        new SecurityScheme()
+                                .name(accessToken)
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name(AUTHORIZATION));
+
+        return new OpenAPI()
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+
+}

--- a/src/main/java/swyp/team5/greening/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/swyp/team5/greening/common/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import swyp.team5.greening.auth.exception.AuthException;
 
 @Slf4j
 @RestControllerAdvice
@@ -44,5 +45,20 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(new ExceptionResponse(message),
                 HttpStatusCode.valueOf(Integer.parseInt(code)));
+    }
+
+    //인증 관련 예외 처리 핸들러
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<ExceptionResponse> authExceptionHandler(
+            AuthException authException
+    ) {
+        String message = authException.getMessage();
+        String code = authException.getCode();
+
+        log.error("HttpStatus : {}, Exception Message : {}", code, message);
+
+        return new ResponseEntity<>(new ExceptionResponse(message),
+                HttpStatusCode.valueOf(Integer.parseInt(code)));
+
     }
 }

--- a/src/main/java/swyp/team5/greening/common/resolver/LogInUserArgumentResolver.java
+++ b/src/main/java/swyp/team5/greening/common/resolver/LogInUserArgumentResolver.java
@@ -1,6 +1,7 @@
 package swyp.team5.greening.common.resolver;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -8,6 +9,8 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import swyp.team5.greening.auth.exception.AuthException;
+import swyp.team5.greening.auth.exception.AuthExceptionMessage;
 import swyp.team5.greening.common.exception.GreeningGlobalException;
 import swyp.team5.greening.user.domain.repository.UserRepository;
 import swyp.team5.greening.user.exception.UserExceptionMessage;
@@ -32,6 +35,11 @@ public class LogInUserArgumentResolver implements HandlerMethodArgumentResolver 
 
         //필터에서 parsing 한 userId 조회
         Long userId = (Long) request.getAttribute("authorize-user-id");
+
+        //만약 user 정보가 요청 정보에 담겨있지 않다면, 인증 예외
+        if (Objects.isNull(userId)) {
+            throw new AuthException(AuthExceptionMessage.UNAUTHORIZED);
+        }
 
         //존재하지 않는 유저라면
         if (!userRepository.existsById(userId)) {

--- a/src/main/java/swyp/team5/greening/mbti/domain/entity/MbtiType.java
+++ b/src/main/java/swyp/team5/greening/mbti/domain/entity/MbtiType.java
@@ -1,4 +1,9 @@
 package swyp.team5.greening.mbti.domain.entity;
 
 public enum MbtiType {
+    INF, ENF,
+    INT, ENT,
+    ISF, ESF,
+    IST, EST
+
 }

--- a/src/main/java/swyp/team5/greening/mbti/infrastructure/MbtiJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/mbti/infrastructure/MbtiJpaRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.team5.greening.mbti.domain.entity.Mbti;
 import swyp.team5.greening.mbti.domain.repository.MbtiRepository;
 
-public interface MbtiJpaRepository extends JpaRepository<Long , Mbti>, MbtiRepository {
+public interface MbtiJpaRepository extends JpaRepository<Mbti , Long>, MbtiRepository {
 
 }

--- a/src/main/java/swyp/team5/greening/mbtiQnA/infrastructure/MbtiJpaAnswerRepository.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/infrastructure/MbtiJpaAnswerRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.team5.greening.mbtiQnA.domain.entity.MbtiAnswer;
 import swyp.team5.greening.mbtiQnA.domain.repository.MbtiAnswerRepository;
 
-public interface MbtiJpaAnswerRepository extends JpaRepository<Long, MbtiAnswer>,
+public interface MbtiJpaAnswerRepository extends JpaRepository<MbtiAnswer, Long>,
         MbtiAnswerRepository {
 
 }

--- a/src/main/java/swyp/team5/greening/mbtiQnA/infrastructure/MbtiQuestionJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/mbtiQnA/infrastructure/MbtiQuestionJpaRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.team5.greening.mbtiQnA.domain.entity.MbtiQuestion;
 import swyp.team5.greening.mbtiQnA.domain.repository.MbtiQuestionRepository;
 
-public interface MbtiQuestionJpaRepository extends JpaRepository<Long, MbtiQuestion>,
+public interface MbtiQuestionJpaRepository extends JpaRepository<MbtiQuestion, Long>,
         MbtiQuestionRepository {
 
 }

--- a/src/main/java/swyp/team5/greening/postCategory/domain/entity/CategoryType.java
+++ b/src/main/java/swyp/team5/greening/postCategory/domain/entity/CategoryType.java
@@ -1,4 +1,15 @@
 package swyp.team5.greening.postCategory.domain.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum CategoryType {
+    QnA("QnA"),
+    FREE_BULLETIN_BOARD("자유게시판"),
+    SHARING("나눔");
+
+
+    private final String description;
 }

--- a/src/main/java/swyp/team5/greening/postCategory/infrastructure/CategoryJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/postCategory/infrastructure/CategoryJpaRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.team5.greening.postCategory.domain.entity.Category;
 import swyp.team5.greening.postCategory.domain.repository.CategoryRepository;
 
-public interface CategoryJpaRepository extends JpaRepository<Long, Category>, CategoryRepository {
+public interface CategoryJpaRepository extends JpaRepository<Category, Long>, CategoryRepository {
 
 }

--- a/src/main/java/swyp/team5/greening/postLike/infrastructure/LikeJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/postLike/infrastructure/LikeJpaRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.team5.greening.postLike.domain.entity.Like;
 import swyp.team5.greening.postLike.domain.repository.LikeRepository;
 
-public interface LikeJpaRepository extends JpaRepository<Long, Like>, LikeRepository {
+public interface LikeJpaRepository extends JpaRepository<Like, Long>, LikeRepository {
 
 }

--- a/src/main/java/swyp/team5/greening/user/controller/LogInController.java
+++ b/src/main/java/swyp/team5/greening/user/controller/LogInController.java
@@ -1,0 +1,32 @@
+package swyp.team5.greening.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import swyp.team5.greening.common.response.ApiResponseDto;
+import swyp.team5.greening.user.dto.request.LogInRequestDto;
+import swyp.team5.greening.user.dto.response.LoginResponseDto;
+import swyp.team5.greening.user.service.KakaoLogInService;
+
+@Tag(name = "유저 로그인 관련 API")
+@RestController
+@RequestMapping("/api/login")
+@RequiredArgsConstructor
+public class LogInController {
+
+    private final KakaoLogInService kakaoLogInService;
+
+    @Operation(summary = "카카오 로그인 API")
+    @PostMapping("/kakao")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<LoginResponseDto> kakaoLogin(@RequestBody LogInRequestDto requestDto) {
+        return ApiResponseDto.of(kakaoLogInService.kakaoLogin(requestDto.code()));
+    }
+
+}

--- a/src/main/java/swyp/team5/greening/user/domain/entity/User.java
+++ b/src/main/java/swyp/team5/greening/user/domain/entity/User.java
@@ -8,10 +8,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import swyp.team5.greening.common.base.BaseTimeEntity;
 
 @Entity
 @Table(name = "users")
+@Getter
+@NoArgsConstructor
 public class User extends BaseTimeEntity {
 
     @Id
@@ -32,4 +37,11 @@ public class User extends BaseTimeEntity {
     @Column(name = "nickname")
     private String nickname;
 
+    @Builder
+    public User(String email, LoginType loginType, String userName, String nickname) {
+        this.email = email;
+        this.loginType = loginType;
+        this.userName = userName;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/swyp/team5/greening/user/domain/repository/UserRepository.java
+++ b/src/main/java/swyp/team5/greening/user/domain/repository/UserRepository.java
@@ -1,7 +1,13 @@
 package swyp.team5.greening.user.domain.repository;
 
+import java.util.Optional;
+import swyp.team5.greening.user.domain.entity.User;
+
 public interface UserRepository {
 
     boolean existsById(Long userId);
 
+    Optional<User> findByEmail(String email);
+
+    User save(User user);
 }

--- a/src/main/java/swyp/team5/greening/user/dto/request/LogInRequestDto.java
+++ b/src/main/java/swyp/team5/greening/user/dto/request/LogInRequestDto.java
@@ -1,0 +1,7 @@
+package swyp.team5.greening.user.dto.request;
+
+public record LogInRequestDto(
+        String code
+) {
+
+}

--- a/src/main/java/swyp/team5/greening/user/dto/response/LoginResponseDto.java
+++ b/src/main/java/swyp/team5/greening/user/dto/response/LoginResponseDto.java
@@ -1,0 +1,8 @@
+package swyp.team5.greening.user.dto.response;
+
+public record LoginResponseDto(
+        String accessToken,
+        boolean newJoin
+) {
+
+}

--- a/src/main/java/swyp/team5/greening/user/infrastructure/KakaoLoginClient.java
+++ b/src/main/java/swyp/team5/greening/user/infrastructure/KakaoLoginClient.java
@@ -1,0 +1,61 @@
+package swyp.team5.greening.user.infrastructure;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import swyp.team5.greening.user.util.BodyConverter;
+
+@Component
+public class KakaoLoginClient {
+
+    @Value(value = "${oauth.kakao.token_base_url}")
+    private String GENERATE_TOKEN_BASE_URL;
+
+    @Value(value = "${oauth.kakao.user_info_base_url}")
+    private String GET_USER_INFO_BASE_URL;
+
+    @Value(value = "${oauth.kakao.security.client_id}")
+    private String CLIENT_ID;
+
+    @Value(value = "${oauth.kakao.security.grant_type}")
+    private String GRANT_TYPE;
+
+    @Value(value = "${oauth.kakao.security.redirect_uri}")
+    private String REDIRECT_URI;
+
+    //인가 코드를 통해 토큰 발급
+    public Map<String, Object> generateToken(String code) {
+        Map<String, String> formData = new HashMap<>();
+        formData.put("code", code);
+        formData.put("client_id", CLIENT_ID);
+        formData.put("grant_type", GRANT_TYPE);
+        formData.put("redirect_uri", REDIRECT_URI);
+
+        return RestClient.builder()
+                .baseUrl(GENERATE_TOKEN_BASE_URL)
+                .build()
+                .post()
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyConverter.fromFormData(formData))
+                .retrieve()
+                .body(Map.class);
+    }
+
+    //토큰을 통해 사용자 정보 조회
+    public Map<String, Object> getUserInfo(String accessToken) {
+
+        return RestClient.builder()
+                .baseUrl(GET_USER_INFO_BASE_URL)
+                .build()
+                .post()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .retrieve()
+                .body(Map.class);
+
+    }
+
+}

--- a/src/main/java/swyp/team5/greening/user/infrastructure/UserJpaRepository.java
+++ b/src/main/java/swyp/team5/greening/user/infrastructure/UserJpaRepository.java
@@ -1,9 +1,12 @@
 package swyp.team5.greening.user.infrastructure;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import swyp.team5.greening.user.domain.entity.User;
 import swyp.team5.greening.user.domain.repository.UserRepository;
 
 public interface UserJpaRepository extends JpaRepository<User, Long>, UserRepository {
+
+    Optional<User> findByEmail(String email);
 
 }

--- a/src/main/java/swyp/team5/greening/user/service/KakaoLogInService.java
+++ b/src/main/java/swyp/team5/greening/user/service/KakaoLogInService.java
@@ -1,0 +1,58 @@
+package swyp.team5.greening.user.service;
+
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import swyp.team5.greening.auth.provider.TokenProvider;
+import swyp.team5.greening.user.domain.entity.LoginType;
+import swyp.team5.greening.user.domain.entity.User;
+import swyp.team5.greening.user.domain.repository.UserRepository;
+import swyp.team5.greening.user.dto.response.LoginResponseDto;
+import swyp.team5.greening.user.infrastructure.KakaoLoginClient;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLogInService {
+
+    private final TokenProvider tokenProvider;
+    private final KakaoLoginClient kakaoLoginClient;
+    private final UserRepository userRepository;
+
+    public LoginResponseDto kakaoLogin(String code) {
+
+        //인가 코드를 통해 카카오 서버 접근 액세스 코드 발급
+        Map<String, Object> mapWithToken = kakaoLoginClient.generateToken(code);
+        String token = (String) mapWithToken.get("access_token");
+
+        //액세스 코드를 통해 사용자 정보 조회
+        Map<String, Object> userInfo = kakaoLoginClient.getUserInfo(token);
+
+        Map<String, String> properties = (Map) userInfo.get("properties");
+        String nickname = properties.get("nickname");
+
+        Map<String, String> kakaoAccount = (Map) userInfo.get("kakao_account");
+        String email = kakaoAccount.get("email");
+
+        //유저 조회
+        User loginUser = userRepository.findByEmail(email)
+                .orElse(User.builder()
+                        .email(email)
+                        .loginType(LoginType.KAKAO)
+                        .userName(nickname)
+                        .nickname(nickname)
+                        .build());
+
+        boolean newJoin = false;
+
+        //처음 로그인 한 회원이라면, 회원가입
+        if (Objects.isNull(loginUser.getId())) {
+            userRepository.save(loginUser);
+            newJoin = true;
+        }
+
+        //사용자 정보를 통해 액세스 토큰 발급
+        String accessToken = tokenProvider.createToken(loginUser.getId());
+        return new LoginResponseDto(accessToken, newJoin);
+    }
+}

--- a/src/main/java/swyp/team5/greening/user/util/BodyConverter.java
+++ b/src/main/java/swyp/team5/greening/user/util/BodyConverter.java
@@ -1,0 +1,31 @@
+package swyp.team5.greening.user.util;
+
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class BodyConverter {
+
+    public static String fromFormData(Map<String, String> formData) {
+        StringBuilder stringBuilder = new StringBuilder();
+
+
+        boolean isFirst = true;
+
+        for (Map.Entry<String,String> entry : formData.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+
+            stringBuilder
+                    .append(isFirst?"":"&")
+                    .append(key)
+                    .append("=")
+                    .append(value);
+            isFirst = false;
+        }
+
+        return stringBuilder.toString();
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,12 @@ jwt:
 springdoc:
   swagger-ui:
     path: /api-docs
+
+oauth:
+  kakao:
+    token_base_url: "https://kauth.kakao.com/oauth/token"
+    user_info_base_url: "https://kapi.kakao.com/v2/user/me"
+    security:
+      client_id: "27e0a3291880d7f8220ddb5e90dd66d6"
+      grant_type: "authorization_code"
+      redirect_uri: "http://localhost:8000/api/oauth2/kakao/redirect"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,7 @@ spring:
 jwt:
   access-expiry-time: 1440  # 24시간
   client-secret: f60b1785232c0e9bc42e687d4d2d5c369ab4122c4c8cded1baaf6ae9ef00f01b  # 32바이트 문자열
+
+springdoc:
+  swagger-ui:
+    path: /api-docs


### PR DESCRIPTION
- closed #7
- closed #16 

### ⛏ 작업 상세 내용

- 스웨거 셋팅
- 카카오 로그인 API 구현
        - 프론트와 소통 후 변경 가능성 있음
- 이외에 오류들 수정

### ✅ 중점적으로 리뷰 할 부분

### 참고사항

- 서버에 배포 후, 프론트에게 스웨거 페이지 및 로그인 구현 완료 정보 전달