### PR TITLE
Feat: 댓글 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,22 +24,33 @@ repositories {
 }
 
 dependencies {
+    //JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    //Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    //MySQL Driver
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    //Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    //JUnit Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    //JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+    //Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 
     //Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    //TestContainer
+    testImplementation "org.testcontainers:testcontainers:1.19.3"
+    testImplementation "org.testcontainers:mysql:1.19.3"
 }
 
 tasks.named('test') {

--- a/src/main/java/swyp/team5/greening/comment/controller/CommentController.java
+++ b/src/main/java/swyp/team5/greening/comment/controller/CommentController.java
@@ -1,0 +1,36 @@
+package swyp.team5.greening.comment.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import swyp.team5.greening.comment.dto.request.SaveCommentRequestDto;
+import swyp.team5.greening.comment.dto.response.SaveCommentResponseDto;
+import swyp.team5.greening.comment.service.CommentCommandService;
+import swyp.team5.greening.common.resolver.LogIn;
+import swyp.team5.greening.common.response.ApiResponseDto;
+
+@Tag(name = "댓글 관련 API")
+@RestController
+@RequestMapping("/api/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentCommandService commentCommandService;
+
+    @Operation(summary = "댓글 작성 API")
+    @PostMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<SaveCommentResponseDto> addComment(
+            @LogIn Long userId,
+            @RequestBody SaveCommentRequestDto requestDto
+    ) {
+        return ApiResponseDto.of(commentCommandService.saveComment(userId, requestDto));
+    }
+
+}

--- a/src/main/java/swyp/team5/greening/comment/controller/CommentController.java
+++ b/src/main/java/swyp/team5/greening/comment/controller/CommentController.java
@@ -4,16 +4,24 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import swyp.team5.greening.comment.dto.request.SaveCommentRequestDto;
+import swyp.team5.greening.comment.dto.response.FindAllCommentResponseDto;
 import swyp.team5.greening.comment.dto.response.SaveCommentResponseDto;
 import swyp.team5.greening.comment.service.CommentCommandService;
+import swyp.team5.greening.comment.service.CommentQueryService;
+import swyp.team5.greening.common.dto.request.PaginationRequestDto;
 import swyp.team5.greening.common.resolver.LogIn;
 import swyp.team5.greening.common.response.ApiResponseDto;
+import swyp.team5.greening.common.response.PaginationApiResponseDto;
 
 @Tag(name = "댓글 관련 API")
 @RestController
@@ -21,16 +29,34 @@ import swyp.team5.greening.common.response.ApiResponseDto;
 @RequiredArgsConstructor
 public class CommentController {
 
+    //명령 전용 서비스
     private final CommentCommandService commentCommandService;
+
+    //조회 전용 서비스
+    private final CommentQueryService commentQueryService;
 
     @Operation(summary = "댓글 작성 API")
     @PostMapping
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<SaveCommentResponseDto> addComment(
             @LogIn Long userId,
-            @RequestBody SaveCommentRequestDto requestDto
+            @Validated @RequestBody SaveCommentRequestDto requestDto
     ) {
         return ApiResponseDto.of(commentCommandService.saveComment(userId, requestDto));
+    }
+
+    @Operation(summary = "게시물 댓글 목록 조회 API")
+    @GetMapping("/posts/{postId}")
+    @ResponseStatus(HttpStatus.OK)
+    public PaginationApiResponseDto<FindAllCommentResponseDto> getComment(
+            @LogIn Long userId,
+            @PathVariable("postId") Long postId,
+            @Validated @ModelAttribute PaginationRequestDto paginationRequestDto
+    ) {
+        return PaginationApiResponseDto.of(commentQueryService.findAllComment(
+                userId, postId,
+                paginationRequestDto.pageNumber(), paginationRequestDto.pageSize()
+        ));
     }
 
 }

--- a/src/main/java/swyp/team5/greening/comment/controller/CommentController.java
+++ b/src/main/java/swyp/team5/greening/comment/controller/CommentController.java
@@ -48,7 +48,7 @@ public class CommentController {
     @Operation(summary = "게시물 댓글 목록 조회 API")
     @GetMapping("/posts/{postId}")
     @ResponseStatus(HttpStatus.OK)
-    public PaginationApiResponseDto<FindAllCommentResponseDto> getComment(
+    public PaginationApiResponseDto<FindAllCommentResponseDto> getAllComment(
             @LogIn Long userId,
             @PathVariable("postId") Long postId,
             @Validated @ModelAttribute PaginationRequestDto paginationRequestDto

--- a/src/main/java/swyp/team5/greening/comment/domain/entity/Comment.java
+++ b/src/main/java/swyp/team5/greening/comment/domain/entity/Comment.java
@@ -6,10 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import swyp.team5.greening.common.base.BaseTimeEntity;
 
 @Entity
 @Table(name = "comments")
+@Getter
+@NoArgsConstructor
 public class Comment extends BaseTimeEntity {
 
     @Id
@@ -26,4 +31,14 @@ public class Comment extends BaseTimeEntity {
     @Column(name = "post_id")
     private Long postId;
 
+    @Builder
+    public Comment(
+            String comment,
+            Long userId,
+            Long postId
+    ) {
+        this.comment = comment;
+        this.userId = userId;
+        this.postId = postId;
+    }
 }

--- a/src/main/java/swyp/team5/greening/comment/domain/repository/CommentQueryRepository.java
+++ b/src/main/java/swyp/team5/greening/comment/domain/repository/CommentQueryRepository.java
@@ -1,0 +1,13 @@
+package swyp.team5.greening.comment.domain.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import swyp.team5.greening.comment.dto.response.FindAllCommentResponseDto;
+
+public interface CommentQueryRepository {
+
+    Page<FindAllCommentResponseDto> findAllComment(
+            Long userId, Long postId, Pageable pageable
+    );
+
+}

--- a/src/main/java/swyp/team5/greening/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/swyp/team5/greening/comment/domain/repository/CommentRepository.java
@@ -1,5 +1,9 @@
 package swyp.team5.greening.comment.domain.repository;
 
+import swyp.team5.greening.comment.domain.entity.Comment;
+
 public interface CommentRepository {
+
+    Comment save(Comment comment);
 
 }

--- a/src/main/java/swyp/team5/greening/comment/domain/repository/CommentRepository.java
+++ b/src/main/java/swyp/team5/greening/comment/domain/repository/CommentRepository.java
@@ -6,4 +6,6 @@ public interface CommentRepository {
 
     Comment save(Comment comment);
 
+    void deleteAll();
+
 }

--- a/src/main/java/swyp/team5/greening/comment/dto/request/SaveCommentRequestDto.java
+++ b/src/main/java/swyp/team5/greening/comment/dto/request/SaveCommentRequestDto.java
@@ -1,0 +1,14 @@
+package swyp.team5.greening.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record SaveCommentRequestDto(
+        @NotNull
+        Long postId,
+
+        @NotBlank
+        String comment
+) {
+
+}

--- a/src/main/java/swyp/team5/greening/comment/dto/response/FindAllCommentResponseDto.java
+++ b/src/main/java/swyp/team5/greening/comment/dto/response/FindAllCommentResponseDto.java
@@ -1,0 +1,21 @@
+package swyp.team5.greening.comment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+public record FindAllCommentResponseDto(
+        Long commentId,
+
+        Long userId,
+
+        String userName,
+
+        String comment,
+
+        @JsonFormat(pattern = "YYYY-MM-DD'T'hh:mm:ss")
+        LocalDateTime createdAt,
+
+        boolean isWriter
+) {
+
+}

--- a/src/main/java/swyp/team5/greening/comment/dto/response/SaveCommentResponseDto.java
+++ b/src/main/java/swyp/team5/greening/comment/dto/response/SaveCommentResponseDto.java
@@ -1,0 +1,7 @@
+package swyp.team5.greening.comment.dto.response;
+
+public record SaveCommentResponseDto(
+        Long id
+) {
+
+}

--- a/src/main/java/swyp/team5/greening/comment/exception/PostExceptionMessage.java
+++ b/src/main/java/swyp/team5/greening/comment/exception/PostExceptionMessage.java
@@ -1,0 +1,16 @@
+package swyp.team5.greening.comment.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import swyp.team5.greening.common.exception.ExceptionMessage;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostExceptionMessage implements ExceptionMessage {
+
+    NOT_FOUND_POST("존재하지 않는 게시글입니다", "404");
+
+    private final String message;
+    private final String code;
+
+}

--- a/src/main/java/swyp/team5/greening/comment/infrastructure/CommentJpaQueryRepository.java
+++ b/src/main/java/swyp/team5/greening/comment/infrastructure/CommentJpaQueryRepository.java
@@ -1,0 +1,34 @@
+package swyp.team5.greening.comment.infrastructure;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import swyp.team5.greening.comment.domain.entity.Comment;
+import swyp.team5.greening.comment.domain.repository.CommentQueryRepository;
+import swyp.team5.greening.comment.dto.response.FindAllCommentResponseDto;
+
+public interface CommentJpaQueryRepository extends JpaRepository<Comment, Long>,
+        CommentQueryRepository {
+
+    @Override
+    @Query("""
+          SELECT new swyp.team5.greening.comment.dto.response.FindAllCommentResponseDto(
+              comment.id, user.id, user.userName, comment.comment, comment.createdAt,
+              case when(user.id = :userId) then true else false end
+          )
+          FROM Comment comment
+          INNER JOIN User user
+          ON user.id = comment.userId
+          INNER JOIN Post post
+          ON post.id = comment.postId
+          WHERE post.id = :postId
+          ORDER BY comment.createdAt desc, comment.id asc
+    """)
+    Page<FindAllCommentResponseDto> findAllComment(
+            @Param("userId") Long userId,
+            @Param("postId") Long postId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/swyp/team5/greening/comment/service/CommentCommandService.java
+++ b/src/main/java/swyp/team5/greening/comment/service/CommentCommandService.java
@@ -1,0 +1,41 @@
+package swyp.team5.greening.comment.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import swyp.team5.greening.comment.domain.entity.Comment;
+import swyp.team5.greening.comment.domain.repository.CommentRepository;
+import swyp.team5.greening.comment.dto.request.SaveCommentRequestDto;
+import swyp.team5.greening.comment.dto.response.SaveCommentResponseDto;
+import swyp.team5.greening.comment.exception.PostExceptionMessage;
+import swyp.team5.greening.common.exception.GreeningGlobalException;
+import swyp.team5.greening.post.domain.repository.PostRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCommandService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    //댓글 작성 로직
+    @Transactional
+    public SaveCommentResponseDto saveComment(
+            Long userId,
+            SaveCommentRequestDto requestDto
+    ) {
+        //게시물 존재 여부 확인
+        if (!postRepository.existsById(requestDto.postId())) {
+            throw new GreeningGlobalException(PostExceptionMessage.NOT_FOUND_POST);
+        }
+
+        Comment saveComment = commentRepository.save(Comment.builder()
+                .postId(requestDto.postId())
+                .userId(userId)
+                .comment(requestDto.comment())
+                .build());
+
+        return new SaveCommentResponseDto(saveComment.getId());
+    }
+
+}

--- a/src/main/java/swyp/team5/greening/comment/service/CommentQueryService.java
+++ b/src/main/java/swyp/team5/greening/comment/service/CommentQueryService.java
@@ -1,0 +1,37 @@
+package swyp.team5.greening.comment.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import swyp.team5.greening.comment.domain.repository.CommentQueryRepository;
+import swyp.team5.greening.comment.dto.response.FindAllCommentResponseDto;
+import swyp.team5.greening.comment.exception.PostExceptionMessage;
+import swyp.team5.greening.common.exception.GreeningGlobalException;
+import swyp.team5.greening.post.domain.repository.PostRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentQueryService {
+
+    private final CommentQueryRepository commentQueryRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public Page<FindAllCommentResponseDto> findAllComment(
+            Long userId, Long postId,
+            Integer pageNumber, Integer pageSize
+    ) {
+
+        //게시물 존재 여부 확인
+        if (!postRepository.existsById(postId)) {
+            throw new GreeningGlobalException(PostExceptionMessage.NOT_FOUND_POST);
+        }
+
+        PageRequest pageRequest = PageRequest.of(pageNumber, pageSize);
+
+        return commentQueryRepository.findAllComment(userId, postId, pageRequest);
+    }
+
+}

--- a/src/main/java/swyp/team5/greening/common/dto/request/PaginationRequestDto.java
+++ b/src/main/java/swyp/team5/greening/common/dto/request/PaginationRequestDto.java
@@ -1,0 +1,24 @@
+package swyp.team5.greening.common.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PaginationRequestDto(
+        @NotNull
+        Integer pageNumber,
+
+        @NotNull
+        Integer pageSize
+) {
+
+    public Integer pageNumber() {
+        return pageNumber - 1;
+    }
+
+    public Integer pageSize() {
+        return pageSize;
+    }
+
+    public int pageOffset() {
+        return pageNumber() * pageSize();
+    }
+}

--- a/src/main/java/swyp/team5/greening/post/domain/entity/Post.java
+++ b/src/main/java/swyp/team5/greening/post/domain/entity/Post.java
@@ -12,10 +12,15 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import swyp.team5.greening.common.base.BaseTimeEntity;
 
 @Entity
 @Table(name = "posts")
+@Getter
+@NoArgsConstructor
 public class Post extends BaseTimeEntity {
 
     @Id
@@ -48,4 +53,22 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = {CascadeType.PERSIST}, orphanRemoval = true)
     private final List<PostImage> postImages = new ArrayList<>();
 
+    @Builder
+    public Post(
+            String title,
+            String content,
+            Long likeCount,
+            Long commentCount,
+            PostState state,
+            Long categoryId,
+            Long userId
+    ) {
+        this.title = title;
+        this.content = content;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.state = state;
+        this.categoryId = categoryId;
+        this.userId = userId;
+    }
 }

--- a/src/main/java/swyp/team5/greening/post/domain/repository/PostRepository.java
+++ b/src/main/java/swyp/team5/greening/post/domain/repository/PostRepository.java
@@ -1,7 +1,13 @@
 package swyp.team5.greening.post.domain.repository;
 
+import swyp.team5.greening.post.domain.entity.Post;
+
 public interface PostRepository {
 
+    Post save(Post post);
+
     boolean existsById(Long id);
+
+    void deleteAll();
 
 }

--- a/src/main/java/swyp/team5/greening/post/domain/repository/PostRepository.java
+++ b/src/main/java/swyp/team5/greening/post/domain/repository/PostRepository.java
@@ -2,4 +2,6 @@ package swyp.team5.greening.post.domain.repository;
 
 public interface PostRepository {
 
+    boolean existsById(Long id);
+
 }

--- a/src/test/java/swyp/team5/greening/auth/infrastructure/JwtTokenProviderTest.java
+++ b/src/test/java/swyp/team5/greening/auth/infrastructure/JwtTokenProviderTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import swyp.team5.greening.auth.property.JwtProperty;
 
+@DisplayName("Jwt 토큰 생성 및 파싱 테스트")
 @ExtendWith(MockitoExtension.class)
 class JwtTokenProviderTest {
 
@@ -26,7 +27,6 @@ class JwtTokenProviderTest {
     private Long id;
 
     @Test
-    @DisplayName("Jwt 토큰 생성 및 파싱 테스트")
     void jwtTokenCreateAndParsingTest() {
         //given
         id = 253L;

--- a/src/test/java/swyp/team5/greening/comment/controller/CommentControllerTest.java
+++ b/src/test/java/swyp/team5/greening/comment/controller/CommentControllerTest.java
@@ -1,0 +1,71 @@
+package swyp.team5.greening.comment.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import swyp.team5.greening.comment.dto.request.SaveCommentRequestDto;
+import swyp.team5.greening.post.domain.entity.Post;
+import swyp.team5.greening.post.domain.entity.PostState;
+import swyp.team5.greening.post.domain.repository.PostRepository;
+import swyp.team5.greening.support.ApiTestSupport;
+
+@DisplayName("댓글 통합 테스트")
+class CommentControllerTest extends ApiTestSupport {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @BeforeEach
+    void init() {
+        postRepository.deleteAll();
+    }
+
+    @DisplayName("댓글 생성 테스트")
+    @Nested
+    class addCommentTest {
+
+        Post post;
+
+        @BeforeEach
+        void setUp() {
+            post = Post.builder()
+                    .title("테스트")
+                    .content("테스트 게시물")
+                    .likeCount(0L)
+                    .commentCount(0L)
+                    .state(PostState.IN_PROGRESS)
+                    .categoryId(1L)
+                    .userId(loginUser.getId())
+                    .build();
+
+            postRepository.save(post);
+        }
+
+        @Test
+        @DisplayName("사용자는 게시물에 댓글을 작성할 수 있다.")
+        void testCase1() throws Exception {
+            //given
+            String comment = "테스트 댓글";
+            SaveCommentRequestDto requestDto = new SaveCommentRequestDto(post.getId(), comment);
+
+            //when
+            ResultActions perform = mockMvc.perform(post("/api/comments")
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(requestDto))
+            );
+
+            //then
+            perform.andExpect(jsonPath("$.data.id").value(post.getId()));
+        }
+    }
+
+}

--- a/src/test/java/swyp/team5/greening/comment/controller/CommentControllerTest.java
+++ b/src/test/java/swyp/team5/greening/comment/controller/CommentControllerTest.java
@@ -2,6 +2,7 @@ package swyp.team5.greening.comment.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,21 +12,33 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
+import swyp.team5.greening.comment.domain.entity.Comment;
+import swyp.team5.greening.comment.domain.repository.CommentRepository;
 import swyp.team5.greening.comment.dto.request.SaveCommentRequestDto;
 import swyp.team5.greening.post.domain.entity.Post;
 import swyp.team5.greening.post.domain.entity.PostState;
 import swyp.team5.greening.post.domain.repository.PostRepository;
 import swyp.team5.greening.support.ApiTestSupport;
+import swyp.team5.greening.user.domain.entity.LoginType;
+import swyp.team5.greening.user.domain.entity.User;
+import swyp.team5.greening.user.domain.repository.UserRepository;
 
 @DisplayName("댓글 통합 테스트")
 class CommentControllerTest extends ApiTestSupport {
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private PostRepository postRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
 
     @BeforeEach
     void init() {
         postRepository.deleteAll();
+        commentRepository.deleteAll();
     }
 
     @DisplayName("댓글 생성 테스트")
@@ -49,6 +62,7 @@ class CommentControllerTest extends ApiTestSupport {
             postRepository.save(post);
         }
 
+
         @Test
         @DisplayName("사용자는 게시물에 댓글을 작성할 수 있다.")
         void testCase1() throws Exception {
@@ -64,7 +78,82 @@ class CommentControllerTest extends ApiTestSupport {
             );
 
             //then
-            perform.andExpect(jsonPath("$.data.id").value(post.getId()));
+            perform.andExpect(status().isOk());
+        }
+    }
+
+    @DisplayName("댓글 조회 테스트")
+    @Nested
+    class getAllCommentTest {
+
+        User anotherUser;
+        String anotherEmail = "test@kakao.com";
+        String anotherName = "다른 테스트 이름";
+
+        Post post;
+
+        Comment comment1;
+        String c1 = "테스트 댓글 1";
+        Comment comment2;
+        String c2 = "테스트 댓글 2";
+
+        @BeforeEach
+        void setUp() {
+            anotherUser = User.builder()
+                    .email(anotherEmail)
+                    .loginType(LoginType.KAKAO)
+                    .userName(anotherName)
+                    .nickname(anotherName)
+                    .build();
+            userRepository.save(anotherUser);
+
+            post = Post.builder()
+                    .title("테스트")
+                    .content("테스트 게시물")
+                    .likeCount(0L)
+                    .commentCount(0L)
+                    .state(PostState.IN_PROGRESS)
+                    .categoryId(1L)
+                    .userId(loginUser.getId())
+                    .build();
+
+            postRepository.save(post);
+
+            comment1 = Comment.builder()
+                    .comment(c1)
+                    .userId(loginUser.getId())
+                    .postId(post.getId())
+                    .build();
+            commentRepository.save(comment1);
+
+            comment2 = Comment.builder()
+                    .comment(c2)
+                    .userId(anotherUser.getId())
+                    .postId(post.getId())
+                    .build();
+            commentRepository.save(comment2);
+        }
+
+        @Test
+        @DisplayName("게시물에 작성된 댓글을 모두 조회할 수 있다. 최신순으로 정렬되며, 자신이 작성한 댓글에 대한 boolean 값을 알맞게 내려준다")
+        void testCase1() throws Exception {
+            //when
+            ResultActions perform = mockMvc.perform(get("/api/comments/posts/" + post.getId())
+                    .header(HttpHeaders.AUTHORIZATION, accessToken)
+                    .param("pageNumber", "1")
+                    .param("pageSize", "100")
+            );
+
+            //then
+            perform.andExpectAll(
+                    jsonPath("$.data.size()").value(2),
+                    jsonPath("$.data[0].commentId").value(comment2.getId()),
+                    jsonPath("$.data[0].comment").value(comment2.getComment()),
+                    jsonPath("$.data[0].isWriter").value(false),
+                    jsonPath("$.data[1].commentId").value(comment1.getId()),
+                    jsonPath("$.data[1].comment").value(comment1.getComment()),
+                    jsonPath("$.data[1].isWriter").value(true)
+            );
         }
     }
 

--- a/src/test/java/swyp/team5/greening/comment/service/CommentCommandServiceTest.java
+++ b/src/test/java/swyp/team5/greening/comment/service/CommentCommandServiceTest.java
@@ -1,0 +1,84 @@
+package swyp.team5.greening.comment.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import swyp.team5.greening.comment.domain.entity.Comment;
+import swyp.team5.greening.comment.domain.repository.CommentRepository;
+import swyp.team5.greening.comment.dto.request.SaveCommentRequestDto;
+import swyp.team5.greening.comment.dto.response.SaveCommentResponseDto;
+import swyp.team5.greening.comment.exception.PostExceptionMessage;
+import swyp.team5.greening.common.exception.GreeningGlobalException;
+import swyp.team5.greening.post.domain.repository.PostRepository;
+
+@DisplayName("댓글 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class CommentCommandServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private CommentCommandService commentCommandService;
+
+    @DisplayName("댓글 생성 테스트")
+    @Nested
+    class saveCommentTest {
+
+        Long userId = 1L;
+        Long postId = 2L;
+        String comment = "댓글입니다~";
+
+        Comment commentEntity = Comment.builder()
+                .postId(postId)
+                .userId(userId)
+                .comment(comment)
+                .build();
+
+        @Test
+        @DisplayName("사용자는 게시물에 댓글을 작성할 수 있다.")
+        void testCase1() {
+            //given
+            given(postRepository.existsById(postId)).willReturn(true);
+            given(commentRepository.save(any(Comment.class))).willReturn(commentEntity);
+            ReflectionTestUtils.setField(commentEntity, "id", 3L);
+
+            //when
+            SaveCommentResponseDto responseDto = commentCommandService.saveComment(
+                    userId, new SaveCommentRequestDto(postId, comment));
+
+            //then
+            verify(postRepository).existsById(postId);
+            verify(commentRepository).save(any(Comment.class));
+            assertThat(responseDto.id()).isEqualTo(commentEntity.getId());
+        }
+
+        @Test
+        @DisplayName("게시물이 존재하지 않을 경우, 예외가 발생한다.")
+        void testCase2() {
+            //given
+            given(postRepository.existsById(postId)).willReturn(false);
+
+            //when
+            ThrowingCallable when = () -> commentCommandService.saveComment(userId, new SaveCommentRequestDto(postId, comment));
+
+            //then
+            verify(commentRepository, times(0)).save(any(Comment.class));
+            assertThatThrownBy(when)
+                    .isInstanceOf(GreeningGlobalException.class)
+                    .hasMessage(PostExceptionMessage.NOT_FOUND_POST.getMessage());
+        }
+    }
+}

--- a/src/test/java/swyp/team5/greening/support/ApiTestSupport.java
+++ b/src/test/java/swyp/team5/greening/support/ApiTestSupport.java
@@ -1,0 +1,57 @@
+package swyp.team5.greening.support;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import swyp.team5.greening.auth.provider.TokenProvider;
+import swyp.team5.greening.user.domain.entity.LoginType;
+import swyp.team5.greening.user.domain.entity.User;
+import swyp.team5.greening.user.domain.repository.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public abstract class ApiTestSupport extends TestContainerSupport{
+
+    protected final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    protected User loginUser;
+    protected String accessToken;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @PostConstruct
+    public void setUpUser() {
+        if (loginUser != null) {
+            return;
+        }
+
+        User user = userRepository.save(User.builder()
+                        .email("test@gmail.com")
+                        .loginType(LoginType.GOOGLE)
+                        .userName("테스트")
+                        .nickname("테스트 닉네임")
+                .build());
+        String token = tokenProvider.createToken(user.getId());
+
+        loginUser = user;
+        this.accessToken = token;
+    }
+
+    protected String toJson(Object object) throws JsonProcessingException {
+        objectMapper.registerModule(new JavaTimeModule());
+        return objectMapper.writeValueAsString(object);
+    }
+
+}

--- a/src/test/java/swyp/team5/greening/support/TestContainerSupport.java
+++ b/src/test/java/swyp/team5/greening/support/TestContainerSupport.java
@@ -1,0 +1,36 @@
+package swyp.team5.greening.support;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public abstract class TestContainerSupport {
+
+    private static final String MYSQL_IMAGE = "mysql:8.0";
+
+    private static final int MYSQL_PORT = 3306;
+
+
+    private static final JdbcDatabaseContainer<?> MYSQL;
+
+    static {
+
+        MYSQL = new MySQLContainer<>(DockerImageName.parse(MYSQL_IMAGE))
+                .withExposedPorts(MYSQL_PORT)
+                .withReuse(true);
+
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    public static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+
+    }
+}
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,26 @@
+spring:
+  sql:
+    init:
+      mode: always
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+jwt:
+  access-expiry-time: 1440  # 24시간
+  client-secret: f60b1785232c0e9bc42e687d4d2d5c369ab4122c4c8cded1baaf6ae9ef00f01b  # 32바이트 문자열
+
+oauth:
+  kakao:
+    token_base_url: "https://kauth.kakao.com/oauth/token"
+    user_info_base_url: "https://kapi.kakao.com/v2/user/me"
+    security:
+      client_id: "27e0a3291880d7f8220ddb5e90dd66d6"
+      grant_type: "authorization_code"
+      redirect_uri: "http://localhost:3000/login/kakao"


### PR DESCRIPTION
- closed #19

### ⛏ 작업 상세 내용

- 게시물 댓글 조회 기능 구현

### ✅ 중점적으로 리뷰 할 부분

- 페이징 관련 처리
- service 및 repository layer 조회 및 명령 분리

### 참고사항

#### 20번 PR을 먼저 처리 후 봐야합니다!