### PR TITLE
Feat: 구글 소셜 로그인 구현

### DIFF
--- a/src/main/java/swyp/team5/greening/user/controller/LogInController.java
+++ b/src/main/java/swyp/team5/greening/user/controller/LogInController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import swyp.team5.greening.common.response.ApiResponseDto;
 import swyp.team5.greening.user.dto.request.LogInRequestDto;
 import swyp.team5.greening.user.dto.response.LoginResponseDto;
+import swyp.team5.greening.user.service.GoogleLogInService;
 import swyp.team5.greening.user.service.KakaoLogInService;
 
 @Tag(name = "유저 로그인 관련 API")
@@ -21,12 +22,20 @@ import swyp.team5.greening.user.service.KakaoLogInService;
 public class LogInController {
 
     private final KakaoLogInService kakaoLogInService;
+    private final GoogleLogInService googleLogInService;
 
     @Operation(summary = "카카오 로그인 API")
     @PostMapping("/kakao")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponseDto<LoginResponseDto> kakaoLogin(@RequestBody LogInRequestDto requestDto) {
         return ApiResponseDto.of(kakaoLogInService.kakaoLogin(requestDto.code()));
+    }
+
+    @Operation(summary = "구글 로그인 API")
+    @PostMapping("/google")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<LoginResponseDto> googleLogin(@RequestBody LogInRequestDto requestDto) {
+        return ApiResponseDto.of(googleLogInService.googleLogin(requestDto.code()));
     }
 
 }

--- a/src/main/java/swyp/team5/greening/user/infrastructure/GoogleLoginClient.java
+++ b/src/main/java/swyp/team5/greening/user/infrastructure/GoogleLoginClient.java
@@ -1,0 +1,68 @@
+package swyp.team5.greening.user.infrastructure;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import swyp.team5.greening.user.util.BodyConverter;
+
+@Component
+public class GoogleLoginClient {
+
+    @Value(value = "${oauth.google.token_base_url}")
+    private String GENERATE_TOKEN_BASE_URL;
+
+    @Value(value = "${oauth.google.user_info_base_url}")
+    private String GET_USER_INFO_BASE_URL;
+
+    @Value(value = "${oauth.google.security.client_id}")
+    private String CLIENT_ID;
+
+    @Value(value = "${oauth.google.security.client_secret}")
+    private String CLIENT_SECRET;
+
+    @Value(value = "${oauth.google.security.grant_type}")
+    private String GRANT_TYPE;
+
+    @Value(value = "${oauth.google.security.redirect_uri}")
+    private String REDIRECT_URI;
+
+    //인가 코드를 통해 토큰 발급
+    public Map<String, Object> generateToken(String code) {
+        //코드 디코딩
+        String decodeCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+
+        Map<String, String> formData = new HashMap<>();
+        formData.put("code", decodeCode);
+        formData.put("client_id", CLIENT_ID);
+        formData.put("client_secret", CLIENT_SECRET);
+        formData.put("grant_type", GRANT_TYPE);
+        formData.put("redirect_uri", REDIRECT_URI);
+
+        return RestClient.builder()
+                .baseUrl(GENERATE_TOKEN_BASE_URL)
+                .build()
+                .post()
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyConverter.fromFormData(formData))
+                .retrieve()
+                .body(Map.class);
+    }
+
+    //토큰을 통해 사용자 정보 조회
+    public Map<String, Object> getUserInfo(String accessToken) {
+
+        return RestClient.builder()
+                .baseUrl(GET_USER_INFO_BASE_URL)
+                .build()
+                .get()
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(Map.class);
+    }
+
+}

--- a/src/main/java/swyp/team5/greening/user/infrastructure/KakaoLoginClient.java
+++ b/src/main/java/swyp/team5/greening/user/infrastructure/KakaoLoginClient.java
@@ -55,7 +55,5 @@ public class KakaoLoginClient {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .retrieve()
                 .body(Map.class);
-
     }
-
 }

--- a/src/main/java/swyp/team5/greening/user/service/GoogleLogInService.java
+++ b/src/main/java/swyp/team5/greening/user/service/GoogleLogInService.java
@@ -1,0 +1,54 @@
+package swyp.team5.greening.user.service;
+
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import swyp.team5.greening.auth.provider.TokenProvider;
+import swyp.team5.greening.user.domain.entity.LoginType;
+import swyp.team5.greening.user.domain.entity.User;
+import swyp.team5.greening.user.domain.repository.UserRepository;
+import swyp.team5.greening.user.dto.response.LoginResponseDto;
+import swyp.team5.greening.user.infrastructure.GoogleLoginClient;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleLogInService {
+
+    private final TokenProvider tokenProvider;
+    private final GoogleLoginClient googleLoginClient;
+    private final UserRepository userRepository;
+
+    public LoginResponseDto googleLogin(String code) {
+        //인가 코드를 통해 카카오 서버 접근 액세스 코드 발급
+        Map<String, Object> mapWithToken = googleLoginClient.generateToken(code);
+        String token = (String) mapWithToken.get("access_token");
+
+        //액세스 코드를 통해 사용자 정보 조회
+        Map<String, Object> userInfo = googleLoginClient.getUserInfo(token);
+
+        String email = (String) userInfo.get("email");
+        String name = (String) userInfo.get("name");
+
+        //유저 조회
+        User loginUser = userRepository.findByEmail(email)
+                .orElse(User.builder()
+                        .email(email)
+                        .loginType(LoginType.KAKAO)
+                        .userName(name)
+                        .nickname(name)
+                        .build());
+
+        boolean newJoin = false;
+
+        //처음 로그인 한 회원이라면, 회원가입
+        if (Objects.isNull(loginUser.getId())) {
+            userRepository.save(loginUser);
+            newJoin = true;
+        }
+
+        //사용자 정보를 통해 액세스 토큰 발급
+        String accessToken = tokenProvider.createToken(loginUser.getId());
+        return new LoginResponseDto(accessToken, newJoin);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,11 @@ oauth:
       client_id: ${KAKAO_CLIENT_ID}
       grant_type: authorization_code
       redirect_uri: ${KAKAO_REDIRECT_URI}
+  google:
+    token_base_url: https://oauth2.googleapis.com/token
+    user_info_base_url: https://www.googleapis.com/oauth2/v2/userinfo
+    security:
+      client_id: ${GOOGLE_CLIENT_ID}
+      client_secret: ${GOOGLE_CLIENT_SECRET}
+      grant_type: authorization_code
+      redirect_uri: ${GOOGLE_REDIRECT_URI}


### PR DESCRIPTION
- closed #8 

### ⛏ 작업 상세 내용

- 구글 소셜로그인 API 구현
  - 전체적인 흐름은 카카오와 동일
  - 필요한 설정 키들 Github Secret에 추가 완료

### ✅ 중점적으로 리뷰 할 부분

### 참고사항
