### PR TITLE
Feat: 게시글 단일 조회 및 삭제 API 구현

### DIFF
--- a/src/main/java/swyp/team5/greening/post/controller/PostController.java
+++ b/src/main/java/swyp/team5/greening/post/controller/PostController.java
@@ -6,6 +6,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,9 +16,13 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import swyp.team5.greening.common.dto.response.ApiResponseDto;
 import swyp.team5.greening.common.resolver.LogIn;
+import swyp.team5.greening.post.domain.entity.Post;
 import swyp.team5.greening.post.dto.request.CreatePostRequestDto;
 import swyp.team5.greening.post.dto.response.CreatePostResponseDto;
+import swyp.team5.greening.post.dto.response.PostResponseDto;
 import swyp.team5.greening.post.service.PostCreateService;
+import swyp.team5.greening.post.service.PostDeleteService;
+import swyp.team5.greening.post.service.PostReadService;
 
 @Tag(name = "게시글 관련 API")
 @RestController
@@ -24,6 +31,8 @@ import swyp.team5.greening.post.service.PostCreateService;
 public class PostController {
 
     private final PostCreateService postCreateService;
+    private final PostDeleteService postDeleteService;
+    private final PostReadService postReadService;
 
     @Operation(summary = "게시글 작성 API")
     @PostMapping
@@ -34,4 +43,23 @@ public class PostController {
     ) {
         return ApiResponseDto.of(postCreateService.createPost(userId, requestDto));
     }
+
+    @Operation(summary = "게시글 단건 조회 API")
+    @GetMapping("/{postId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponseDto<PostResponseDto> getPost(@PathVariable Long postId) {
+        return ApiResponseDto.of(postReadService.findPostDto(postId));
+    }
+
+    @Operation(summary = "게시글 삭제 API")
+    @DeleteMapping("/{postId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deletePost(
+        @LogIn Long userId,
+        @PathVariable Long postId
+    ) {
+        postDeleteService.deletePost(userId, postId);
+    }
+
 }
+

--- a/src/main/java/swyp/team5/greening/post/domain/entity/Post.java
+++ b/src/main/java/swyp/team5/greening/post/domain/entity/Post.java
@@ -66,4 +66,8 @@ public class Post extends BaseTimeEntity {
         this.categoryId = categoryId;
         this.userId = userId;
     }
+
+    public void changeState(PostState state) {
+        this.state = state;
+    }
 }

--- a/src/main/java/swyp/team5/greening/post/domain/entity/PostContent.java
+++ b/src/main/java/swyp/team5/greening/post/domain/entity/PostContent.java
@@ -11,9 +11,11 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import swyp.team5.greening.common.base.BaseTimeEntity;
 
+@Getter
 @Entity
 @Table(name = "post_contents")
 @NoArgsConstructor

--- a/src/main/java/swyp/team5/greening/post/domain/repository/PostRepository.java
+++ b/src/main/java/swyp/team5/greening/post/domain/repository/PostRepository.java
@@ -1,6 +1,9 @@
 package swyp.team5.greening.post.domain.repository;
 
+import java.util.List;
+import java.util.Optional;
 import swyp.team5.greening.post.domain.entity.Post;
+import swyp.team5.greening.post.domain.entity.PostState;
 
 public interface PostRepository {
 
@@ -9,5 +12,8 @@ public interface PostRepository {
     boolean existsById(Long id);
 
     void deleteAll();
+
+    Optional<Post> findByIdAndState(Long postId, PostState state);
+//    List<Post> findAllByState(PostState state); // 전체 조회 기능
 
 }

--- a/src/main/java/swyp/team5/greening/post/dto/response/PostResponseDto.java
+++ b/src/main/java/swyp/team5/greening/post/dto/response/PostResponseDto.java
@@ -1,0 +1,25 @@
+package swyp.team5.greening.post.dto.response;
+
+import java.util.List;
+import swyp.team5.greening.post.domain.entity.Post;
+import swyp.team5.greening.post.domain.entity.PostType;
+
+public record PostResponseDto(
+    Long postId,
+    String title,
+    Long categoryId,
+    List<ContentDto> content
+) {
+    public static PostResponseDto from(Post post) {
+        return new PostResponseDto(
+            post.getId(),
+            post.getTitle(),
+            post.getCategoryId(),
+            post.getPostImages().stream()
+                .map(content -> new ContentDto(content.getType(), content.getContent()))
+                .toList()
+        );
+    }
+
+    public record ContentDto(PostType type, String value) {}
+}

--- a/src/main/java/swyp/team5/greening/post/service/PostDeleteService.java
+++ b/src/main/java/swyp/team5/greening/post/service/PostDeleteService.java
@@ -1,0 +1,30 @@
+package swyp.team5.greening.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp.team5.greening.common.exception.GreeningGlobalException;
+import swyp.team5.greening.post.domain.entity.Post;
+import swyp.team5.greening.post.domain.entity.PostState;
+import swyp.team5.greening.post.domain.repository.PostRepository;
+import swyp.team5.greening.post.exception.PostExceptionMessage;
+
+@Service
+@RequiredArgsConstructor
+public class PostDeleteService {
+
+    private final PostRepository postRepository;
+
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        Post post = postRepository.findByIdAndState(postId, PostState.IN_PROGRESS)
+            .orElseThrow(() -> new GreeningGlobalException(PostExceptionMessage.NOT_FOUND_POST));
+
+        if (!post.getUserId().equals(userId)) {
+            throw new GreeningGlobalException(PostExceptionMessage.NOT_FOUND_POST); // 권한 예외 분리해도 됨
+        }
+
+        post.changeState(PostState.DELETED);
+    }
+
+}

--- a/src/main/java/swyp/team5/greening/post/service/PostReadService.java
+++ b/src/main/java/swyp/team5/greening/post/service/PostReadService.java
@@ -1,0 +1,27 @@
+package swyp.team5.greening.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp.team5.greening.common.exception.GreeningGlobalException;
+import swyp.team5.greening.post.domain.entity.Post;
+import swyp.team5.greening.post.domain.entity.PostState;
+import swyp.team5.greening.post.domain.repository.PostRepository;
+import swyp.team5.greening.post.dto.response.PostResponseDto;
+import swyp.team5.greening.post.exception.PostExceptionMessage;
+
+@Service
+@RequiredArgsConstructor
+public class PostReadService {
+
+    private final PostRepository postRepository;
+
+    @Transactional(readOnly = true)
+    public PostResponseDto findPostDto(Long postId) {
+        Post post = postRepository.findByIdAndState(postId, PostState.IN_PROGRESS)
+            .orElseThrow(() -> new GreeningGlobalException(PostExceptionMessage.NOT_FOUND_POST));
+
+        // 트랜잭션 안에서 DTO로 변환
+        return PostResponseDto.from(post);
+    }
+}

--- a/src/test/java/swyp/team5/greening/post/controller/PostControllerTest.java
+++ b/src/test/java/swyp/team5/greening/post/controller/PostControllerTest.java
@@ -1,6 +1,6 @@
 package swyp.team5.greening.post.controller;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
@@ -14,6 +14,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
+import swyp.team5.greening.post.domain.entity.Post;
 import swyp.team5.greening.post.domain.repository.PostRepository;
 import swyp.team5.greening.post.dto.request.CreatePostRequestDto;
 import swyp.team5.greening.support.ApiTestSupport;
@@ -38,13 +39,7 @@ class PostControllerTest extends ApiTestSupport {
     @DisplayName("사용자는 게시글을 작성할 수 있다.")
     void createPost() throws Exception {
         // given
-        List<CreatePostRequestDto.ContentDto> contents = List.of(
-            new CreatePostRequestDto.ContentDto("TEXT", "1번 텍스트"),
-            new CreatePostRequestDto.ContentDto("IMAGE", "https://example.com/1.png"),
-            new CreatePostRequestDto.ContentDto("TEXT", "2번 텍스트"),
-            new CreatePostRequestDto.ContentDto("IMAGE", "https://example.com/2.png")
-        );
-        CreatePostRequestDto requestDto = new CreatePostRequestDto("테스트 게시글", 1L, contents);
+        CreatePostRequestDto requestDto = getSamplePostDto();
 
         // when
         ResultActions result = mockMvc.perform(post("/api/posts")
@@ -56,5 +51,59 @@ class PostControllerTest extends ApiTestSupport {
         result.andExpect(status().isOk())
             .andExpect(jsonPath("$.data.postId").exists())
             .andExpect(jsonPath("$.data.postId").isNumber());
+    }
+
+    @Test
+    @DisplayName("사용자는 게시글을 단건 조회할 수 있다.")
+    void getSinglePost() throws Exception {
+        // given
+        Post savedPost = savePost(); // 직접 저장 또는 service 활용
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/posts/{id}", savedPost.getId())
+            .header(HttpHeaders.AUTHORIZATION, accessToken));
+
+        // then
+        result.andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.postId").value(savedPost.getId()))
+            .andExpect(jsonPath("$.data.title").value("테스트 게시글"));
+    }
+
+    @Test
+    @DisplayName("사용자는 게시글을 삭제할 수 있다.")
+    void deletePost() throws Exception {
+        // given
+        Post savedPost = savePost();
+
+        // when
+        ResultActions result = mockMvc.perform(delete("/api/posts/{id}", savedPost.getId())
+            .header(HttpHeaders.AUTHORIZATION, accessToken));
+
+        // then
+        result.andExpect(status().isNoContent());
+    }
+
+    private CreatePostRequestDto getSamplePostDto() {
+        List<CreatePostRequestDto.ContentDto> contents = List.of(
+            new CreatePostRequestDto.ContentDto("TEXT", "1번 텍스트"),
+            new CreatePostRequestDto.ContentDto("IMAGE", "https://example.com/1.png"),
+            new CreatePostRequestDto.ContentDto("TEXT", "2번 텍스트"),
+            new CreatePostRequestDto.ContentDto("IMAGE", "https://example.com/2.png")
+        );
+        return new CreatePostRequestDto("테스트 게시글", 1L, contents);
+    }
+
+    private Post savePost() {
+        CreatePostRequestDto dto = getSamplePostDto();
+        return postRepository.save(
+            Post.builder()
+                .title(dto.title())
+                .userId(1L)
+                .categoryId(dto.categoryId())
+                .likeCount(0L)
+                .commentCount(0L)
+                .state(swyp.team5.greening.post.domain.entity.PostState.IN_PROGRESS)
+                .build()
+        );
     }
 }

--- a/src/test/java/swyp/team5/greening/post/service/PostCommandServiceTest.java
+++ b/src/test/java/swyp/team5/greening/post/service/PostCommandServiceTest.java
@@ -21,7 +21,7 @@ import swyp.team5.greening.post.dto.request.CreatePostRequestDto;
 import swyp.team5.greening.post.dto.response.CreatePostResponseDto;
 import swyp.team5.greening.post.exception.PostExceptionMessage;
 
-@DisplayName("게시글 단위 테스트")
+@DisplayName("게시글 서비스 단위 테스트")
 @ExtendWith(MockitoExtension.class)
 class PostCommandServiceTest {
 
@@ -31,22 +31,28 @@ class PostCommandServiceTest {
     @InjectMocks
     private PostCreateService postCreateService;
 
-    @DisplayName("게시글 생성 테스트")
+    @InjectMocks
+    private PostReadService postReadService;
+
+    @InjectMocks
+    private PostDeleteService postDeleteService;
+
+    private final Long userId = 1L;
+    private final String title = "테스트 게시글 제목";
+    private final Long categoryId = 5L;
+
+    private final List<CreatePostRequestDto.ContentDto> contentList = List.of(
+        new CreatePostRequestDto.ContentDto("TEXT", "본문1"),
+        new CreatePostRequestDto.ContentDto("IMAGE", "http://image.com/test.jpg")
+    );
+
     @Nested
-    class createPostTest {
-
-        Long userId = 1L;
-        String title = "테스트 게시글 제목";
-        Long categoryId = 5L;
-
-        CreatePostRequestDto.ContentDto content1 = new CreatePostRequestDto.ContentDto("TEXT", "본문1");
-        CreatePostRequestDto.ContentDto content2 = new CreatePostRequestDto.ContentDto("IMAGE", "http://image.com/test.jpg");
-
-        List<CreatePostRequestDto.ContentDto> contentList = List.of(content1, content2);
+    @DisplayName("게시글 생성 테스트")
+    class CreatePostTest {
 
         @Test
         @DisplayName("게시글을 성공적으로 작성할 수 있다")
-        void testCase1() {
+        void create_success() {
             // given
             Post post = Post.builder()
                 .title(title)
@@ -56,9 +62,7 @@ class PostCommandServiceTest {
                 .likeCount(0L)
                 .commentCount(0L)
                 .build();
-
             ReflectionTestUtils.setField(post, "id", 100L);
-
             given(postRepository.save(any(Post.class))).willReturn(post);
 
             // when
@@ -67,17 +71,15 @@ class PostCommandServiceTest {
             );
 
             // then
-            verify(postRepository, times(1)).save(any(Post.class));
             assertThat(result.postId()).isEqualTo(100L);
+            verify(postRepository).save(any(Post.class));
         }
 
         @Test
         @DisplayName("제목이 null이면 예외가 발생한다")
-        void testCase2() {
-            // when
+        void create_fail_titleNull() {
             CreatePostRequestDto request = new CreatePostRequestDto(null, categoryId, contentList);
 
-            // then
             assertThatThrownBy(() -> postCreateService.createPost(userId, request))
                 .isInstanceOf(GreeningGlobalException.class)
                 .hasMessage(PostExceptionMessage.NOT_FOUND_POST.getMessage());
@@ -85,12 +87,98 @@ class PostCommandServiceTest {
 
         @Test
         @DisplayName("본문이 비어있으면 예외가 발생한다")
-        void testCase3() {
-            // when
+        void create_fail_emptyContent() {
             CreatePostRequestDto request = new CreatePostRequestDto(title, categoryId, List.of());
 
-            // then
             assertThatThrownBy(() -> postCreateService.createPost(userId, request))
+                .isInstanceOf(GreeningGlobalException.class)
+                .hasMessage(PostExceptionMessage.NOT_FOUND_POST.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 단건 조회 테스트")
+    class ReadPostTest {
+
+        @Test
+        @DisplayName("게시글을 정상적으로 조회할 수 있다")
+        void read_success() {
+            // given
+            Post post = Post.builder()
+                .title(title)
+                .userId(userId)
+                .categoryId(categoryId)
+                .state(PostState.IN_PROGRESS)
+                .likeCount(0L)
+                .commentCount(0L)
+                .build();
+            ReflectionTestUtils.setField(post, "id", 200L);
+
+            given(postRepository.findByIdAndState(200L, PostState.IN_PROGRESS)).willReturn(java.util.Optional.of(post));
+
+            // when
+            Post result = postReadService.findPost(200L);
+
+            // then
+            assertThat(result.getId()).isEqualTo(200L);
+            assertThat(result.getTitle()).isEqualTo(title);
+        }
+
+        @Test
+        @DisplayName("게시글이 없으면 예외가 발생한다")
+        void read_fail_notFound() {
+            given(postRepository.findByIdAndState(999L, PostState.IN_PROGRESS)).willReturn(java.util.Optional.empty());
+
+            assertThatThrownBy(() -> postReadService.findPost(999L))
+                .isInstanceOf(GreeningGlobalException.class)
+                .hasMessage(PostExceptionMessage.NOT_FOUND_POST.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 삭제 테스트")
+    class DeletePostTest {
+
+        @Test
+        @DisplayName("게시글을 성공적으로 삭제할 수 있다 (상태 변경)")
+        void delete_success() {
+            // given
+            Post post = Post.builder()
+                .title(title)
+                .userId(userId)
+                .categoryId(categoryId)
+                .state(PostState.IN_PROGRESS)
+                .likeCount(0L)
+                .commentCount(0L)
+                .build();
+            ReflectionTestUtils.setField(post, "id", 300L);
+
+            given(postRepository.findByIdAndState(300L, PostState.IN_PROGRESS)).willReturn(java.util.Optional.of(post));
+
+            // when
+            postDeleteService.deletePost(userId, 300L);
+
+            // then
+            assertThat(post.getState()).isEqualTo(PostState.DELETED);
+        }
+
+        @Test
+        @DisplayName("작성자가 아니면 삭제할 수 없다")
+        void delete_fail_wrongUser() {
+            Post post = Post.builder()
+                .title(title)
+                .userId(999L) // 다른 사용자
+                .categoryId(categoryId)
+                .state(PostState.IN_PROGRESS)
+                .likeCount(0L)
+                .commentCount(0L)
+                .build();
+            ReflectionTestUtils.setField(post, "id", 301L);
+
+            given(postRepository.findByIdAndState(301L, PostState.IN_PROGRESS)).willReturn(java.util.Optional.of(post));
+
+            // then
+            assertThatThrownBy(() -> postDeleteService.deletePost(userId, 301L))
                 .isInstanceOf(GreeningGlobalException.class)
                 .hasMessage(PostExceptionMessage.NOT_FOUND_POST.getMessage());
         }


### PR DESCRIPTION
- closed #이슈번호

### ⛏ 작업 상세 내용

- 게시글 단일 조회 및 삭제 API 구현

### ✅ 중점적으로 리뷰 할 부분

- postState로 soft Delete 구현

### 참고사항

- 컨트롤러 테스트가 작동하지 않는데 이 부분이 잘 이해가 안됩니다. 
- mbti 테이블이 없어서 에러가 난다고 하는데 이 부분이 해결이 안됩니다